### PR TITLE
根据程序的可读性、便捷性提出修改意见

### DIFF
--- a/PopMenu/GlowImageView.h
+++ b/PopMenu/GlowImageView.h
@@ -6,12 +6,25 @@
 //  Copyright (c) 2014年 华捷 iOS软件开发工程师 曾宪华. All rights reserved.
 //
 
+// ==========================================
+//  GlowImageView 菜单按钮 UIView  处理点击事件等
+// ==========================================
+
 #import <UIKit/UIKit.h>
 
 @interface GlowImageView : UIButton
 
+/**
+ *  设置阴影的偏移值（+，+）表示向左下偏移 默认为 （0,0）
+ */
 @property (nonatomic, assign) CGSize glowOffset;
+/**
+ *  设置阴影的模糊度 默认为： 5
+ */
 @property (nonatomic, assign) CGFloat glowAmount;
+/**
+ *  设置阴影的颜色 默认为 grayColor 灰色
+ */
 @property (nonatomic, strong) UIColor *glowColor;
 
 @end

--- a/PopMenu/GlowImageView.m
+++ b/PopMenu/GlowImageView.m
@@ -8,55 +8,32 @@
 
 #import "GlowImageView.h"
 
-@interface GlowImageView () {
-    CGColorSpaceRef colorSpaceRef;
-    CGColorRef glowColorRef;
-}
 
-@end
 
 @implementation GlowImageView
 
-- (void)setGlowColor:(UIColor *)newGlowColor {
-    if (newGlowColor != _glowColor) {
-        CGColorRelease(glowColorRef);
-        
-        _glowColor = newGlowColor;
-        glowColorRef = CGColorCreate(colorSpaceRef, CGColorGetComponents(_glowColor.CGColor));
-    }
-    [self setNeedsDisplay];
+/**
+ *  设置阴影的颜色
+ */
+- (void)setGlowColor:(UIColor *)newGlowColor{
+    _glowColor = newGlowColor;
+    self.layer.shadowColor = newGlowColor.CGColor;
 }
 
-- (id)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
-    if (self) {
-        // Initialization code
-        colorSpaceRef = CGColorSpaceCreateDeviceRGB();
-        
-        self.glowOffset = CGSizeMake(0.0, 0.0);
-        self.glowAmount = 30.0;
-        self.glowColor = [UIColor greenColor];
+- (instancetype)initWithFrame:(CGRect)frame{
+    if (self =[super initWithFrame:frame]) {
+        [self setUpProperty];
     }
     return self;
 }
-
-- (void)dealloc {
-    CGColorRelease(glowColorRef);
-    CGColorSpaceRelease(colorSpaceRef);
-}
-
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    
-    // Drawing code
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSaveGState(context);
-    
-    CGContextSetShadow(context, self.glowOffset, self.glowAmount);
-    CGContextSetShadowWithColor(context, self.glowOffset, self.glowAmount, glowColorRef);
-    
-    CGContextRestoreGState(context);
+/**
+ *   根据阴影 设置图层 默认属性
+ */
+- (void)setUpProperty{
+    self.layer.shadowColor = [UIColor grayColor].CGColor;
+    self.layer.shadowOffset = CGSizeMake(0.0, 0.0);
+    self.layer.shadowOpacity = 5;
+    self.layer.masksToBounds = NO;
 }
 
 @end

--- a/PopMenu/MenuButton.h
+++ b/PopMenu/MenuButton.h
@@ -6,18 +6,22 @@
 //  Copyright (c) 2014年 华捷 iOS软件开发工程师 曾宪华. All rights reserved.
 //
 
+// ==========================================
+//  MenuButton 菜单视图 UIView  处理点击事件等
+// ==========================================
 #import <UIKit/UIKit.h>
 
 @class MenuItem;
-
 typedef void(^DidSelctedItemCompletedBlock)(MenuItem *menuItem);
-
 
 @interface MenuButton : UIView
 
+/**
+ *  点击操作
+ */
 @property (nonatomic, copy) DidSelctedItemCompletedBlock didSelctedItemCompleted;
 
-- (instancetype)initWithFrame:(CGRect)frame
-                     menuItem:(MenuItem *)menuItem;
+#pragma mark - init
+- (instancetype)initWithFrame:(CGRect)frame menuItem:(MenuItem *)menuItem;
 
 @end

--- a/PopMenu/MenuButton.m
+++ b/PopMenu/MenuButton.m
@@ -26,8 +26,9 @@
 
 @implementation MenuButton
 
-- (instancetype)initWithFrame:(CGRect)frame
-                     menuItem:(MenuItem *)menuItem {
+
+
+- (instancetype)initWithFrame:(CGRect)frame menuItem:(MenuItem *)menuItem {
     
     self = [super initWithFrame:frame];
     if (self) {

--- a/PopMenu/MenuItem.h
+++ b/PopMenu/MenuItem.h
@@ -6,19 +6,37 @@
 //  Copyright (c) 2014年 华捷 iOS软件开发工程师 曾宪华. All rights reserved.
 //
 
+// ==========================================
+//  MenuItem 菜单元素  数据模型
+// ==========================================
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface MenuItem : NSObject
 
+/**
+ *   标题
+ */
 @property (nonatomic, copy) NSString *title;
+/**
+ *  配图
+ */
 @property (nonatomic, strong) UIImage *iconImage;
+/**
+ *
+ */
 @property (nonatomic, strong) UIColor *glowColor;
+/**
+ *  按钮索引
+ */
 @property (nonatomic, assign) NSUInteger index;
 
-- (instancetype)initWithTitle:(NSString *)title
-                     iconName:(NSString *)iconName
-                    glowColor:(UIColor *)glowColor
-                        index:(NSUInteger)index;
+#pragma mark - 初始话 init
+- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName  glowColor:(UIColor *)glowColor  index:(NSUInteger)index NS_DEPRECATED_IOS(2_0,2_0);
+
+- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor NS_AVAILABLE_IOS(2_0);
+
++ (instancetype)itemWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor NS_AVAILABLE_IOS(2_0);
 
 @end

--- a/PopMenu/MenuItem.m
+++ b/PopMenu/MenuItem.m
@@ -10,18 +10,24 @@
 
 @implementation MenuItem
 
-- (instancetype)initWithTitle:(NSString *)title
-                     iconName:(NSString *)iconName
-                    glowColor:(UIColor *)glowColor
-                        index:(NSUInteger)index {
-    self = [super init];
-    if (self) {
+
+- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor index:(NSUInteger)index {
+    MenuItem *item =  [self initWithTitle:title iconName:iconName glowColor:glowColor];
+    item.index = index;
+    return item;
+}
+- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor{
+   
+    if ( self = [super init]) {
         self.title = title;
         self.iconImage = [UIImage imageNamed:iconName];
         self.glowColor = glowColor;
-        self.index = index;
     }
     return self;
 }
 
++(instancetype)itemWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor{
+    MenuItem *item = [[self alloc ] initWithTitle:title iconName:iconName glowColor:glowColor];
+    return item;
+}
 @end

--- a/PopMenu/PopMenu.h
+++ b/PopMenu/PopMenu.h
@@ -10,29 +10,63 @@
 #import "MenuItem.h"
 
 typedef NS_ENUM(NSInteger, PopMenuAnimationType) {
+    /** 从下部入 下部出*/
     kPopMenuAnimationTypeSina = 0,
+    /** 从右侧入 左侧出*/
     kPopMenuAnimationTypeNetEase = 1,
 };
 
+/**
+ *  选中菜单按钮 操作
+ *
+ *  @param selectedItem 菜单按钮
+ */
 typedef void(^DidSelectedItemBlock)(MenuItem *selectedItem);
 
+// ==========================================
+//  PopMenu 菜单栏
+// ==========================================
 @interface PopMenu : UIView
 
+/**
+ *  菜单动画格式
+ */
 @property (nonatomic, assign) PopMenuAnimationType menuAnimationType;
-
+/**
+ *  是否显示
+ */
 @property (nonatomic, assign, readonly) BOOL isShowed;
-
+/**
+ *  菜单中菜单元素
+ */
 @property (nonatomic, strong, readonly) NSArray *items;
-
+/**
+ *  点击菜单元素,Block会把点击的菜单元素当成参数返回给用户，用户可以拿到菜单元素对点击，做相应的操作
+ */
 @property (nonatomic, copy) DidSelectedItemBlock didSelectedItemCompletion;
 
-- (instancetype)initWithFrame:(CGRect)frame
-                        items:(NSArray *)items;
+#pragma mark - init 初始化
+- (instancetype)initWithFrame:(CGRect)frame items:(NSArray *)items;
 
+#pragma mark - show
+#pragma mark 将菜单显示到某个视图上
 - (void)showMenuAtView:(UIView *)containerView;
-- (void)showMenuAtView:(UIView *)containerView
-            startPoint:(CGPoint)startPoint
-              endPoint:(CGPoint)endPoint;
+
+#pragma mark 控制菜单从哪个点的进 和 出
+/**
+ *  将菜单  开始 现实到哪个point 上  在哪个 point 结束
+ *
+ *  此效果用于 在 PopMenu AnimationType 为 kPopMenuAnimationTypeNetEase 有效，
+ *  @param containerView 显示在哪个视图容器上
+ *  @param startPoint    菜单从哪个 点 进入 容器 展示效果
+ *  @param endPoint      菜单从哪个 点 出 容器
+ */
+- (void)showMenuAtView:(UIView *)containerView startPoint:(CGPoint)startPoint endPoint:(CGPoint)endPoint;
+
+#pragma mark - dismiss
+/**
+ *  容器dismiss
+ */
 - (void)dismissMenu;
 
 @end

--- a/PopMenu/PopMenu.m
+++ b/PopMenu/PopMenu.m
@@ -39,8 +39,7 @@
 
 #pragma mark - Life Cycle
 
-- (id)initWithFrame:(CGRect)frame
-              items:(NSArray *)items {
+- (id)initWithFrame:(CGRect)frame items:(NSArray *)items {
     
     self = [super initWithFrame:frame];
     if (self) {
@@ -52,6 +51,7 @@
     return self;
 }
 
+// 设置属性
 - (void)setup {
     self.backgroundColor = [UIColor clearColor];
     
@@ -96,9 +96,7 @@
     [self showMenuAtView:containerView startPoint:startPoint endPoint:endPoint];
 }
 
-- (void)showMenuAtView:(UIView *)containerView
-            startPoint:(CGPoint)startPoint
-              endPoint:(CGPoint)endPoint {
+- (void)showMenuAtView:(UIView *)containerView startPoint:(CGPoint)startPoint endPoint:(CGPoint)endPoint {
     if (self.isShowed) {
         return;
     }
@@ -116,7 +114,9 @@
 }
 
 #pragma mark - 私有方法
-
+/**
+ *  添加菜单按钮
+ */
 - (void)showButtons {
     NSArray *items = [self menuItems];
     
@@ -162,7 +162,9 @@
         [self initailzerAnimationWithToPostion:toRect formPostion:fromRect atView:menuButton beginTime:delayInSeconds];
     }
 }
-
+/**
+ *  隐藏按钮
+ */
 - (void)hidenButtons {
     NSArray *items = [self menuItems];
     
@@ -195,7 +197,7 @@
 }
 
 /**
- *  通过目标的参数，获取一个grid布局
+ *  通过目标的参数，获取一个grid布局  网格布局
  *
  *  @param perRowItemCount   每行有多少列
  *  @param perColumItemCount 每列有多少行
@@ -208,15 +210,8 @@
  *
  *  @return 返回一个已经处理好的gridItem frame
  */
-- (CGRect)getFrameWithItemCount:(NSInteger)itemCount
-                perRowItemCount:(NSInteger)perRowItemCount
-              perColumItemCount:(NSInteger)perColumItemCount
-                      itemWidth:(CGFloat)itemWidth
-                     itemHeight:(NSInteger)itemHeight
-                       paddingX:(CGFloat)paddingX
-                       paddingY:(CGFloat)paddingY
-                        atIndex:(NSInteger)index
-                         onPage:(NSInteger)page {
+- (CGRect)getFrameWithItemCount:(NSInteger)itemCount perRowItemCount:(NSInteger)perRowItemCount          perColumItemCount:(NSInteger)perColumItemCount itemWidth:(CGFloat)itemWidth itemHeight:(NSInteger)itemHeight paddingX:(CGFloat)paddingX  paddingY:(CGFloat)paddingY atIndex:(NSInteger)index                onPage:(NSInteger)page {
+    
     NSUInteger rowCount = itemCount / perRowItemCount + (itemCount % perColumItemCount > 0 ? 1 : 0);
     CGFloat insetY = (CGRectGetHeight(self.bounds) - (itemHeight + paddingY) * rowCount) / 2.0;
     
@@ -226,7 +221,6 @@
     CGRect itemFrame = CGRectMake(originX, originY + insetY, itemWidth, itemHeight);
     return itemFrame;
 }
-
 
 #pragma mark - Animation
 

--- a/PopMenuExample/Pods/XHRealTimeBlur/XHRealTimeBlur/XHRealTimeBlur.h
+++ b/PopMenuExample/Pods/XHRealTimeBlur/XHRealTimeBlur/XHRealTimeBlur.h
@@ -5,6 +5,10 @@
 //  Created by 曾 宪华 on 14-9-7.
 //  Copyright (c) 2014年 曾宪华 QQ群: (142557668) QQ:543413507  Gmail:xhzengAIB@gmail.com. All rights reserved.
 //
+// ==========================================
+//  XHRealTimeBlur 蒙版  实时模糊
+// ==========================================
+
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -38,37 +42,49 @@ typedef NS_ENUM(NSInteger, XHBlurStyle) {
 @interface XHRealTimeBlur : UIView
 
 /**
- *  Default is XHBlurStyleTranslucent
+ *  Default is XHBlurStyleTranslucent  蒙版动画状态
  */
 @property (nonatomic, assign) XHBlurStyle blurStyle;
-
+/**
+ *  蒙版是否显示
+ */
 @property (nonatomic, assign) BOOL showed;
 
-// Default is 0.3
+// Default is 0.3  蒙版显示时间 即蒙版从进入 到 动画完成的 时间 默认 0.3 从进入到动画执行 0.3秒
 @property (nonatomic, assign) NSTimeInterval showDuration;
 
-// Default is 0.3
+// Default is 0.3  蒙版消失时间 即蒙版从消失 到 动画完成的 时间 默认 0.3 从消失到动画执行 0.3秒
 @property (nonatomic, assign) NSTimeInterval disMissDuration;
 
 /**
- *  是否触发点击手势，默认关闭
+ *  是否触发点击手势，默认关闭 蒙版是否有点击事件
  */
 @property (nonatomic, assign) BOOL hasTapGestureEnable;
 
+#pragma mark - 蒙版显示或者消失时， 做的操作
+#pragma mark WillShow 即将显示
 @property (nonatomic, copy) WillShowBlurViewBlcok willShowBlurViewcomplted;
+#pragma mark DidShow  已经显示
 @property (nonatomic, copy) DidShowBlurViewBlcok didShowBlurViewcompleted;
-
+#pragma mark WillDismiss 即将消失
 @property (nonatomic, copy) WillDismissBlurViewBlcok willDismissBlurViewCompleted;
+#pragma mark DidDismiss  已经消失
 @property (nonatomic, copy) DidDismissBlurViewBlcok didDismissBlurViewCompleted;
 
 
+#pragma mark - show
 - (void)showBlurViewAtView:(UIView *)currentView;
 
 - (void)showBlurViewAtViewController:(UIViewController *)currentViewContrller;
 
+#pragma mark - disMiss
 - (void)disMiss;
 
 @end
+
+// ==========================================
+//  UIView (XHRealTimeBlur)蒙版  实时模糊 分类
+// ==========================================
 
 @interface UIView (XHRealTimeBlur)
 

--- a/PopMenuExample/PopMenuExample/Base.lproj/Main.storyboard
+++ b/PopMenuExample/PopMenuExample/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="13F1066" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -41,6 +41,9 @@
                             <constraint firstItem="BHX-Cw-uMJ" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="-20" id="tT0-Tf-aKu"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="iconView" destination="BHX-Cw-uMJ" id="NTN-Oy-ejh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/PopMenuExample/PopMenuExample/ViewController.m
+++ b/PopMenuExample/PopMenuExample/ViewController.m
@@ -11,6 +11,7 @@
 #import "PopMenu.h"
 
 @interface ViewController ()
+@property (weak, nonatomic) IBOutlet UIImageView *iconView;
 
 @property (nonatomic, strong) PopMenu *popMenu;
 
@@ -20,35 +21,35 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view, typically from a nib.
 }
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
+    
 }
 
 - (void)showMenu {
     NSMutableArray *items = [[NSMutableArray alloc] initWithCapacity:3];
-    MenuItem *menuItem = [[MenuItem alloc] initWithTitle:@"Flickr" iconName:@"post_type_bubble_flickr" glowColor:[UIColor grayColor] index:0];
+    
+    MenuItem *menuItem = [MenuItem itemWithTitle:@"Flickr" iconName:@"post_type_bubble_flickr" glowColor:[UIColor redColor]];
     [items addObject:menuItem];
     
-    menuItem = [[MenuItem alloc] initWithTitle:@"Googleplus" iconName:@"post_type_bubble_googleplus" glowColor:[UIColor colorWithRed:0.000 green:0.840 blue:0.000 alpha:1.000] index:0];
+    menuItem = [MenuItem  itemWithTitle:@"Googleplus" iconName:@"post_type_bubble_googleplus" glowColor:[UIColor colorWithRed:0.000 green:0.840 blue:0.000 alpha:1.000]];
     [items addObject:menuItem];
     
-    menuItem = [[MenuItem alloc] initWithTitle:@"Instagram" iconName:@"post_type_bubble_instagram" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] index:0];
+    menuItem = [MenuItem  itemWithTitle:@"Instagram" iconName:@"post_type_bubble_instagram" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] ];
     [items addObject:menuItem];
     
-    menuItem = [[MenuItem alloc] initWithTitle:@"Twitter" iconName:@"post_type_bubble_twitter" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] index:0];
+    menuItem = [MenuItem   itemWithTitle:@"Twitter" iconName:@"post_type_bubble_twitter" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] ];
     [items addObject:menuItem];
     
-    menuItem = [[MenuItem alloc] initWithTitle:@"Youtube" iconName:@"post_type_bubble_youtube" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] index:0];
+    menuItem = [MenuItem  itemWithTitle:@"Youtube" iconName:@"post_type_bubble_youtube" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] ];
+    [items addObject:menuItem];
+    // @"post_type_bubble_facebook"
+    menuItem = [MenuItem itemWithTitle:@"Facebook" iconName:nil glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] ];
     [items addObject:menuItem];
     
-    menuItem = [[MenuItem alloc] initWithTitle:@"Facebook" iconName:@"post_type_bubble_facebook" glowColor:[UIColor colorWithRed:0.687 green:0.000 blue:0.000 alpha:1.000] index:0];
-    [items addObject:menuItem];
-    
-    if (!_popMenu) {
+    if (!_popMenu) { //
         _popMenu = [[PopMenu alloc] initWithFrame:self.view.bounds items:items];
         _popMenu.menuAnimationType = kPopMenuAnimationTypeNetEase;
     }
@@ -56,12 +57,14 @@
         return;
     }
     _popMenu.didSelectedItemCompletion = ^(MenuItem *selectedItem) {
-        
+        NSLog(@"%@",selectedItem.title);
     };
     
-//    [_popMenu showMenuAtView:self.view];
+    [_popMenu showMenuAtView:self.view];
     
-    [_popMenu showMenuAtView:self.view startPoint:CGPointMake(CGRectGetWidth(self.view.bounds) - 60, CGRectGetHeight(self.view.bounds)) endPoint:CGPointMake(60, CGRectGetHeight(self.view.bounds))];
+//    [_popMenu showMenuAtView:self.view startPoint:CGPointMake(CGRectGetWidth(self.view.bounds) - 60, CGRectGetHeight(self.view.bounds)) endPoint:CGPointMake(60, CGRectGetHeight(self.view.bounds))];
+    
+//    [_popMenu showMenuAtView:self.view startPoint:CGPointMake(CGRectGetWidth(self.view.bounds) - 60, CGRectGetHeight(self.view.bounds)) endPoint:CGPointMake(60, CGRectGetHeight(self.view.bounds))];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
更改方案:
1、MenuItem .h
修改了Item模型的初始化方法，因为index索引，是在PopMenu内部设置的，所有不需要暴露出来
- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName  glowColor:(UIColor *)glowColor  index:(NSUInteger)index NS_DEPRECATED_IOS(2_0,2_0);
  增加了一个init方法，和构造方法
- (instancetype)initWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor NS_AVAILABLE_IOS(2_0);
- (instancetype)itemWithTitle:(NSString *)title iconName:(NSString *)iconName glowColor:(UIColor *)glowColor NS_AVAILABLE_IOS(2_0);
  2、 GlowImageView.h
  修改了.m中所有方法，将c语言方法，改成了OC方法，直接对图层操作，摒弃了Quartz2D技术
- 增加了注释，提高程序的可读性和可交换性
